### PR TITLE
Added method to build a 32bit image

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ To build alternate versions of slackware, pass gnu-make the RELEASE variable, li
 
 	$> make image RELEASE=slackware64-13.37 IMG_NAME=$HOME/my_slackware:13.37
 
+Or for a 32bit version:
+
+	$> make image TARGET_ARCH=i586 RELEASE=slackware-14.2
+
 Index
 =====
 

--- a/get_paths.rb
+++ b/get_paths.rb
@@ -5,7 +5,7 @@ require 'open-uri'
 module Slackware
   class Repo
     DEFAULT_MIRROR = "http://mirrors1.kernel.org/slackware"
-    DEFAULT_RELEASE = "slackware64-current"
+    DEFAULT_RELEASE = "slackware"+ENV["SW_ARCH"]+"-current"
     RE_FILELIST = /.*(\d{4}-\d{2}-\d{2} \d{2}:\d{2})\s\.\/(\w*)\/(.*\.t.z)\n?/
 
     def initialize(release = nil, mirror = nil)

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -2,7 +2,7 @@ FROM vbatts/slackware
 MAINTAINER Vincent Batts <vbatts@slackware.com>
 
 RUN slackpkg -batch=on -default_answer=y update
-RUN slackpkg -batch=on -default_answer=y install httpd-2.4.6-x86_64-1 apr-util-1.5.1-x86_64-1 sqlite-3.7.17-x86_64-1 cyrus-sasl-2.1.23-x86_64-5 apr-1.4.6-x86_64-1
+RUN slackpkg -batch=on -default_answer=y install httpd-2.4.6 apr-util-1.5.1 sqlite-3.7.17 cyrus-sasl-2.1.23 apr-1.4.6
 RUN chmod +x /etc/rc.d/rc.httpd
 EXPOSE 80
 VOLUME ["/var/www","/etc/httpd","/var/log/httpd"]

--- a/mkimage-slackware.sh
+++ b/mkimage-slackware.sh
@@ -2,9 +2,10 @@
 # Generate a very minimal filesystem from slackware
 
 set -e
+SW_ARCH=$(( if [ -z ${SW_ARCH+x} ]; then echo 64; else echo ${SW_ARCH}; fi ))
 BUILD_NAME=${BUILD_NAME:-"slackware"}
 VERSION=${VERSION:="current"}
-RELEASE=${RELEASE:-"slackware64-${VERSION}"}
+RELEASE=${RELEASE:-"slackware${SW_ARCH}-${VERSION}"}
 MIRROR=${MIRROR:-"http://slackware.osuosl.org"}
 CACHEFS=${CACHEFS:-"/tmp/slackware/${RELEASE}"}
 ROOTFS=${ROOTFS:-"/tmp/rootfs-${BUILD_NAME}"}


### PR DESCRIPTION
It's kind of a hack, but I needed a 32bit version (don't ask...) and so I did these changes. Maybe someone else needs 32bit also, so why not share the results. I called the resulting image "slackware32" in our own repository, because I'd like to stick to 64bit being the default for image "slackware" ;-).