### PR TITLE
Workaround for moby/moby/#27789

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ all: mkimage-slackware.sh
 	for version in $(VERSIONS) ; do \
 		$(MAKE) $(RELEASENAME)-$${version}.tar && \
 		$(MAKE) VERSION=$${version} clean && \
-		cat $(RELEASENAME)-$${version}.tar | docker import -c "CMD [\"sh\"]"  - $(USER)/$(NAME):$${version} && \
+		cat $(RELEASENAME)-$${version}.tar | docker import -c "CMD ['/bin/sh']"  - $(USER)/$(NAME):$${version} && \
 		docker run -i --rm $(USER)/$(NAME):$${version} /usr/bin/echo "$(USER)/$(NAME):$${version} :: Success." ; \
 	done && \
 	docker tag $(USER)/$(NAME):$(LATEST) $(USER)/$(NAME):latest


### PR DESCRIPTION
This issue is fixed in Docker 1.13, but many distributions still include
1.12. This change should change nothing for those already on 1.13+.